### PR TITLE
Swapping regex access to be compatible with python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5"
   - "3.6"
   - "3.7"
 script: make

--- a/facturedata/core.py
+++ b/facturedata/core.py
@@ -700,7 +700,7 @@ def parse_facture_json_line(line, filename, linenum):
 
     m = re.match(r'.*facture_json: (.*)', line)
     if m:
-        json_text = m[1]
+        json_text = m.group(1)
         result = None
         try:
             result = json.loads(json_text)

--- a/facturedata/core.py
+++ b/facturedata/core.py
@@ -4,11 +4,10 @@ import collections
 import json
 import sys
 
-ordered_dict_version = (3,6)
+ordered_dict_version = (3, 6)
 HAS_DEFAULT_ORDERED_DICT = sys.version_info > ordered_dict_version
 
 #############################################################################
-
 
 
 class ConfError(Exception):
@@ -465,6 +464,7 @@ def formatted_single_record_lines(attrs, indent):
 
     >>> formatted_single_record_lines(attrs, 2)[0]
     '  21000010000,           -- id'
+
     """
 
     with_value_str = []

--- a/tests/examples/json_output/factureconf.py
+++ b/tests/examples/json_output/factureconf.py
@@ -28,35 +28,39 @@
 # you can be confident that if you make changes here and the output of running
 # facture is what you expect, you're good... there are no additional side
 # effects you need to be aware of.
+#
+# One important note is if you're running Python <= 3.5 then the table 'attrs'
+# must be defined in an OrderedDict in order to retain attr write order!
 
+import collections
 
 def conf_tables():
     default_date = '2018-01-01 00:00:00'
     return {
         'products': {
-            'attrs': {
-                'id': {'seq': {'start': 21000000000}},
-                'classified_code': {'default': '0000001234'},
-                'created_at': {'default': default_date},
-                'updated_at': {'default': default_date}
-            }
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 21000000000}}),
+                ('classified_code', {'default': '0000001234'}),
+                ('created_at', {'default': default_date}),
+                ('updated_at', {'default': default_date})
+            ])
         },
         'retailer_products': {
-            'attrs': {
-                'id': {'seq': {'start': 22000000000}},
-                'product_id': {},
-                'retailer_id': {},
-                'created_at': {'default': default_date},
-                'updated_at': {'default': default_date}
-            }
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 22000000000}}),
+                ('product_id', {}),
+                ('retailer_id', {}),
+                ('created_at', {'default': default_date}),
+                ('updated_at', {'default': default_date}),
+            ])
         },
         'warehouses': {
-            'attrs': {
-                'id': {'seq': {'start': 23000000000}},
-                'created_at': {'default': default_date},
-                'updated_at': {'default': default_date}
-            }
-        }
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 23000000000}}),
+                ('created_at', {'default': default_date}),
+                ('updated_at', {'default': default_date})
+            ])
+        },
     }
 
 

--- a/tests/examples/sql_inject_target/factureconf.py
+++ b/tests/examples/sql_inject_target/factureconf.py
@@ -28,34 +28,38 @@
 # you can be confident that if you make changes here and the output of running
 # facture is what you expect, you're good... there are no additional side
 # effects you need to be aware of.
+#
+# One important note is if you're running Python <= 3.5 then the table 'attrs'
+# must be defined in an OrderedDict in order to retain attr write order!
 
+import collections
 
 def conf_tables():
     return {
         'actors': {
             'target': 'actors',
-            'attrs': {
-                'id': {'seq': {'start': 10}},
-                'job_run_id': {},
-                'first_name': {'default': None},
-                'last_name': {'default': None}
-            }
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 10}}),
+                ('job_run_id', {}),
+                ('first_name', {'default': None}),
+                ('last_name', {'default': None})
+            ])
         },
         'films': {
             'target': 'films',
-            'attrs': {
-                'id': {'seq': {'start': 100}},
-                'name': {'default': None},
-                'year': {'default': None},
-            }
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 100}}),
+                ('name', {'default': None}),
+                ('year', {'default': None}),
+            ])
         },
         'roles': {
             'target': 'roles',
-            'attrs': {
-                'id': {'seq': {'start': 1000}},
-                'actor_id': {},
-                'film_id': {}
-            }
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 1000}}),
+                ('actor_id', {}),
+                ('film_id', {})
+            ])
         },
     }
 


### PR DESCRIPTION
`__getitem__` is only available on python >= 3.6.
https://docs.python.org/3/library/re.html#re.Match.__getitem__
`group` should be a compatible drop in replacement.