### PR TITLE
Adding new base type ref_strs which will replace facture_anchors with values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ test: clean-test-output
 	./facturedata/__main__.py --conf-dir="tests/examples/sql_inject_target"
 	diff tests/examples/sql_inject_target/expected_result.sql test_output/sql_inject_target/result.sql && echo OK
 
+	cp tests/examples/advanced_functionality/original.sql test_output/sql_inject_target/result.sql
+	./facturedata/__main__.py --conf-dir="tests/examples/advanced_functionality" --skip-targets --output-type=json > test_output/sql_inject_target/debug_intermediate.json
+	./facturedata/__main__.py --conf-dir="tests/examples/advanced_functionality"
+	diff tests/examples/advanced_functionality/expected_result.sql test_output/sql_inject_target/result.sql && echo OK
+
+
 clean-test-output:
 	rm -rf test_output
 	mkdir -p test_output/json_output

--- a/facturedata/core.py
+++ b/facturedata/core.py
@@ -273,7 +273,7 @@ def enhance_with_referenced_foreign_ids(data):
 
 
 def enhance_with_reference_objects(data):
-    """This enhances the data by updating strings with facture anchors
+    """This enhances the data by updating reference objects with facture anchors
     """
     result = copy.deepcopy(data)
     for x in result:

--- a/facturedata/core.py
+++ b/facturedata/core.py
@@ -3,7 +3,7 @@ import re
 import collections
 import json
 import sys
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 ordered_dict_version = (3, 6)
 HAS_DEFAULT_ORDERED_DICT = sys.version_info > ordered_dict_version
@@ -11,7 +11,7 @@ HAS_DEFAULT_ORDERED_DICT = sys.version_info > ordered_dict_version
 #############################################################################
 
 
-class FactureRefObj(metaclass=ABCMeta):
+class FactureRefObj:
 
     @abstractmethod
     def anchors(self):

--- a/tests/examples/advanced_functionality/expected_result.sql
+++ b/tests/examples/advanced_functionality/expected_result.sql
@@ -1,0 +1,71 @@
+insert into products (
+  id
+)
+values
+-- facture_json: {"target_name": "products", "position": "start"}
+
+-- facture_group_basic_workflow_grouping
+(
+  1100  -- id
+),
+
+-- facture_group_basic_workflow_grouping
+(
+  1101  -- id
+)
+
+-- facture_json: {"target_name": "products", "position": "end"}
+;
+
+insert into workflows (
+  id,
+  name,
+  query,
+  created_by
+)
+values
+-- facture_json: {"target_name": "workflows", "position": "start"}
+
+-- facture_group_basic_workflow_grouping
+(
+  200,                                                              -- id
+  'Tracking Dwight',                                                -- name
+  'select * from orders where product_id = 1100 and user_id = 111', -- query
+  110                                                               -- created_by
+),
+
+-- facture_group_basic_workflow_grouping
+(
+  201,                              -- id
+  'Fetch all orders',               -- name
+  'select * from orders where 1=1', -- query
+  111                               -- created_by
+)
+
+-- facture_json: {"target_name": "workflows", "position": "end"}
+;
+
+insert into users (
+  id,
+  first_name,
+  last_name
+)
+values
+-- facture_json: {"target_name": "users", "position": "start"}
+
+-- facture_group_basic_workflow_grouping
+(
+  110,       -- id
+  'Michael', -- first_name
+  'Scott'    -- last_name
+),
+
+-- facture_group_basic_workflow_grouping
+(
+  111,       -- id
+  'Dwight',  -- first_name
+  'Schrute'  -- last_name
+)
+
+-- facture_json: {"target_name": "users", "position": "end"}
+;

--- a/tests/examples/advanced_functionality/factureconf.py
+++ b/tests/examples/advanced_functionality/factureconf.py
@@ -1,0 +1,131 @@
+#############################################################################
+# What is this file?
+#############################################################################
+#
+# This file is used to show some of the more advanced features of facture.
+# Refer to the `sql_injection_target` example for a more basic use case before
+# looking into this
+#
+#
+#############################################################################
+# What are the advanced topics?
+#############################################################################
+# 1. ReferenceObjects:
+#       Facture is able to evaluate objects that match the `FactureRefObj`
+#       interface. The `StringRefObj` is an example of how you could create
+#       a lazily evaluated string that allows you to reference facture anchors
+#       in more complex data types.
+#
+
+import collections
+import re
+
+
+class StringRefObj:
+
+    ANCHOR_FORMAT = "facture_anchor{{{}}}"
+
+    def __init__(self, string):
+        self._anchors = self._regex_anchors(string)
+        self.anchor_values = {}
+        self.raw_string = string
+
+    @staticmethod
+    def _regex_anchors(string):
+        reg_anchor = re.compile(r'(?<=facture_anchor\{)[^}]+')
+        return re.findall(reg_anchor, string)
+
+    def anchors(self):
+        return list(set(self._anchors))
+
+    def bind(self, anchor, value):
+        self.anchor_values[anchor] = value
+
+    def eval(self):
+        result = self.raw_string
+        for anchor in self.anchors():
+            result = result.replace(StringRefObj.ANCHOR_FORMAT.format(anchor), str(self.anchor_values[anchor]))
+        return result
+
+
+def conf_tables():
+    return {
+        'users': {
+            'target': 'users',
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 10}}),
+                ('first_name', {'default': None}),
+                ('last_name', {'default': None})
+            ])
+        },
+        'workflows': {
+            'target': 'workflows',
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 100}}),
+                ('name', {}),
+                ('query', {}),
+                ('created_by', {}),
+            ])
+        },
+        'products': {
+            'target': 'products',
+            'attrs': collections.OrderedDict([
+                ('id', {'seq': {'start': 1000}}),
+            ])
+        },
+    }
+
+
+def conf_data():
+    return [
+        {
+            'group': 'facture_group_basic_workflow_grouping',
+            'offset': 100,
+            'data': [
+                ['users a_us1', {'attrs': {
+                    'first_name': 'Michael',
+                    'last_name': 'Scott'
+                }}],
+                ['users a_us2', {'attrs': {
+                    'first_name': 'Dwight',
+                    'last_name': 'Schrute'
+                }}],
+                ['products p_1', {}],
+                ['products p_2', {}],
+                ['workflows w_1', {
+                    'attrs': {'name': 'Tracking Dwight'},
+                    'refs': {'created_by': '.a_us1.id'},
+                    'ref_objs': {'query': StringRefObj('select * from orders where product_id = facture_anchor{.p_1.id} and user_id = facture_anchor{.a_us2.id}')}}
+                 ],
+                ['workflows w_2', {
+                    'refs': {'created_by': '.a_us2.id'},
+                    'attrs': {'query': 'select * from orders where 1=1', 'name': 'Fetch all orders'}
+                }]
+            ]
+        }
+    ]
+
+
+def conf_targets():
+    return [
+        {
+            'name': 'users',
+            'type': 'section_in_file',
+            'filename': 'test_output/sql_inject_target/result.sql',
+            'section_name': 'users'
+        },
+        {
+            'name': 'products',
+            'type': 'section_in_file',
+            'filename': 'test_output/sql_inject_target/result.sql',
+            'section_name': 'products'
+        },
+        {
+            'name': 'workflows',
+            'type': 'section_in_file',
+            'filename': 'test_output/sql_inject_target/result.sql',
+            'section_name': 'workflows'
+        }
+    ]
+
+

--- a/tests/examples/advanced_functionality/original.sql
+++ b/tests/examples/advanced_functionality/original.sql
@@ -1,0 +1,31 @@
+insert into products (
+  id
+)
+values
+-- facture_json: {"target_name": "products", "position": "start"}
+-- THIS WILL BE REPLACED
+-- facture_json: {"target_name": "products", "position": "end"}
+;
+
+insert into workflows (
+  id,
+  name,
+  query,
+  created_by
+)
+values
+-- facture_json: {"target_name": "workflows", "position": "start"}
+-- THIS WILL BE REPLACED
+-- facture_json: {"target_name": "workflows", "position": "end"}
+;
+
+insert into users (
+  id,
+  first_name,
+  last_name
+)
+values
+-- facture_json: {"target_name": "users", "position": "start"}
+-- THIS WILL BE REPLACED
+-- facture_json: {"target_name": "users", "position": "end"}
+;

--- a/tests/examples/json_output/expected_output.json
+++ b/tests/examples/json_output/expected_output.json
@@ -18,7 +18,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  23000010000,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {},
                     "tablestr": "warehouses w"
                 },
@@ -45,7 +45,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  21000010000,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {},
                     "tablestr": "products p1"
                 },
@@ -72,7 +72,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  21000010001,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {},
                     "tablestr": "products p2"
                 },
@@ -101,7 +101,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  22000010000,           -- id\n  21000010000,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {
                         "product_id": ".p1.id",
                         "retailer_id": ".w.id"
@@ -136,7 +136,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  22000010001,           -- id\n  21000010001,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {
                         "product_id": ".p2.id",
                         "retailer_id": ".w.id"
@@ -173,7 +173,7 @@
                 "output_sql": "-- facture_group_prod2\n(\n  23000001001,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {},
                     "tablestr": "warehouses w"
                 },
@@ -200,7 +200,7 @@
                 "output_sql": "-- facture_group_prod2\n(\n  21000001002,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {},
                     "tablestr": "products p"
                 },
@@ -229,7 +229,7 @@
                 "output_sql": "-- facture_group_prod2\n(\n  22000001002,           -- id\n  21000001002,           -- product_id\n  23000001001,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
-                    "ref_strs": {},
+                    "ref_objs": {},
                     "refs": {
                         "product_id": ".p.id",
                         "retailer_id": ".w.id"

--- a/tests/examples/json_output/expected_output.json
+++ b/tests/examples/json_output/expected_output.json
@@ -18,6 +18,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  23000010000,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {},
                     "tablestr": "warehouses w"
                 },
@@ -44,6 +45,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  21000010000,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {},
                     "tablestr": "products p1"
                 },
@@ -70,6 +72,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  21000010001,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {},
                     "tablestr": "products p2"
                 },
@@ -98,6 +101,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  22000010000,           -- id\n  21000010000,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {
                         "product_id": ".p1.id",
                         "retailer_id": ".w.id"
@@ -132,6 +136,7 @@
                 "output_sql": "-- facture_group_prod1\n(\n  22000010001,           -- id\n  21000010001,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {
                         "product_id": ".p2.id",
                         "retailer_id": ".w.id"
@@ -168,6 +173,7 @@
                 "output_sql": "-- facture_group_prod2\n(\n  23000001001,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {},
                     "tablestr": "warehouses w"
                 },
@@ -194,6 +200,7 @@
                 "output_sql": "-- facture_group_prod2\n(\n  21000001002,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {},
                     "tablestr": "products p"
                 },
@@ -222,6 +229,7 @@
                 "output_sql": "-- facture_group_prod2\n(\n  22000001002,           -- id\n  21000001002,           -- product_id\n  23000001001,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
                 "raw": {
                     "attrs": {},
+                    "ref_strs": {},
                     "refs": {
                         "product_id": ".p.id",
                         "retailer_id": ".w.id"

--- a/tests/examples/sql_inject_target/expected_result.sql
+++ b/tests/examples/sql_inject_target/expected_result.sql
@@ -35,9 +35,9 @@ values
 
 -- facture_group_shawshank_redemption
 (
-  200,                        -- id
-  'Shawshank Redemption 110', -- name
-  '1994'                      -- year
+  200,                    -- id
+  'Shawshank Redemption', -- name
+  '1994'                  -- year
 )
 
 -- facture_json: {"target_name": "films", "position": "end"}

--- a/tests/examples/sql_inject_target/expected_result.sql
+++ b/tests/examples/sql_inject_target/expected_result.sql
@@ -35,9 +35,9 @@ values
 
 -- facture_group_shawshank_redemption
 (
-  200,                    -- id
-  'Shawshank Redemption', -- name
-  '1994'                  -- year
+  200,                        -- id
+  'Shawshank Redemption 110', -- name
+  '1994'                      -- year
 )
 
 -- facture_json: {"target_name": "films", "position": "end"}

--- a/tests/examples/sql_inject_target/factureconf.py
+++ b/tests/examples/sql_inject_target/factureconf.py
@@ -80,7 +80,9 @@ def conf_data():
                     'first_name': 'Tim',
                     'last_name': 'Robbins'
                 }}],
-                ['films f', {'attrs': {'name': 'Shawshank Redemption', 'year': '1994'}}],
+                ['films f', {'attrs': {'year': '1994'},
+                             'ref_strs': {'name': 'Shawshank Redemption facture_anchor{.a_mf.id}'}}
+                 ],
                 ['roles r1', {'refs': {'actor_id': '.a_mf.id', 'film_id': '.f.id'}}],
                 ['roles r1', {'refs': {'actor_id': '.a_tr.id', 'film_id': '.f.id'}}]
             ]

--- a/tests/examples/sql_inject_target/factureconf.py
+++ b/tests/examples/sql_inject_target/factureconf.py
@@ -33,35 +33,6 @@
 # must be defined in an OrderedDict in order to retain attr write order!
 
 import collections
-import re
-
-
-class StringRefObj:
-
-    ANCHOR_FORMAT = "facture_anchor{{{}}}"
-
-    def __init__(self, string):
-        self._anchors = self._regex_anchors(string)
-        self.anchor_values = {}
-        self.raw_string = string
-
-    @staticmethod
-    def _regex_anchors(string):
-        reg_anchor = re.compile(r'(?<=facture_anchor\{)[^}]+')
-        return re.findall(reg_anchor, string)
-
-    def anchors(self):
-        return list(set(self._anchors))
-
-    def bind(self, anchor, value):
-        self.anchor_values[anchor] = value
-
-    def eval(self):
-        result = self.raw_string
-        for anchor in self.anchors():
-            result = result.replace(StringRefObj.ANCHOR_FORMAT.format(anchor), str(self.anchor_values[anchor]))
-        return result
-
 
 def conf_tables():
     return {
@@ -109,10 +80,7 @@ def conf_data():
                     'first_name': 'Tim',
                     'last_name': 'Robbins'
                 }}],
-                ['films f', {
-                     'attrs': {'year': '1994'},
-                     'ref_objs': {'name': StringRefObj('Shawshank Redemption facture_anchor{.a_mf.id}')}}
-                 ],
+                ['films f', {'attrs': {'year': '1994', 'name': 'Shawshank Redemption'}}],
                 ['roles r1', {'refs': {'actor_id': '.a_mf.id', 'film_id': '.f.id'}}],
                 ['roles r1', {'refs': {'actor_id': '.a_tr.id', 'film_id': '.f.id'}}]
             ]


### PR DESCRIPTION
It would be nice to be able to create lazily loaded strings or objects to allow for more complex relations between objects generated by facture.

This PR tries to add this functionality in two different ways.

The first commit introduces a 'ref_strs' field which allows for a string to be passed in with 'facture_anchor{<anchor>}' annotations which will automatically be filled in during sql generation. 

The second commit swaps over to a more general approach. Instead of adding a new 'ref_strs' field we add a new 'ref_objs' field and defines an interface that users can implement. A user can supply any class to this field and facture will automatically bind anchor values and evaluate the object once all anchors are attached. This gives us the flexibility to add new types of bindings as needed.


Opening this PR to see if it's worth adding this into facture