### PR TITLE
Add support to use a 'select 1,2,3 union all' SQL format instead of values clause

### DIFF
--- a/tests/examples/advanced_functionality/expected_result.sql
+++ b/tests/examples/advanced_functionality/expected_result.sql
@@ -1,19 +1,17 @@
 insert into products (
   id
 )
-values
 -- facture_json: {"target_name": "products", "position": "start"}
-
--- facture_group_basic_workflow_grouping
+values
 (
+  -- facture_group_basic_workflow_grouping
   1100  -- id
 ),
 
--- facture_group_basic_workflow_grouping
 (
+  -- facture_group_basic_workflow_grouping
   1101  -- id
 )
-
 -- facture_json: {"target_name": "products", "position": "end"}
 ;
 
@@ -23,25 +21,23 @@ insert into workflows (
   query,
   created_by
 )
-values
 -- facture_json: {"target_name": "workflows", "position": "start"}
-
--- facture_group_basic_workflow_grouping
+values
 (
+  -- facture_group_basic_workflow_grouping
   200,                                                              -- id
   'Tracking Dwight',                                                -- name
   'select * from orders where product_id = 1100 and user_id = 111', -- query
   110                                                               -- created_by
 ),
 
--- facture_group_basic_workflow_grouping
 (
+  -- facture_group_basic_workflow_grouping
   201,                              -- id
   'Fetch all orders',               -- name
   'select * from orders where 1=1', -- query
   111                               -- created_by
 )
-
 -- facture_json: {"target_name": "workflows", "position": "end"}
 ;
 
@@ -50,22 +46,20 @@ insert into users (
   first_name,
   last_name
 )
-values
 -- facture_json: {"target_name": "users", "position": "start"}
-
--- facture_group_basic_workflow_grouping
+values
 (
+  -- facture_group_basic_workflow_grouping
   110,       -- id
   'Michael', -- first_name
   'Scott'    -- last_name
 ),
 
--- facture_group_basic_workflow_grouping
 (
+  -- facture_group_basic_workflow_grouping
   111,       -- id
   'Dwight',  -- first_name
   'Schrute'  -- last_name
 )
-
 -- facture_json: {"target_name": "users", "position": "end"}
 ;

--- a/tests/examples/advanced_functionality/original.sql
+++ b/tests/examples/advanced_functionality/original.sql
@@ -1,7 +1,6 @@
 insert into products (
   id
 )
-values
 -- facture_json: {"target_name": "products", "position": "start"}
 -- THIS WILL BE REPLACED
 -- facture_json: {"target_name": "products", "position": "end"}
@@ -13,7 +12,6 @@ insert into workflows (
   query,
   created_by
 )
-values
 -- facture_json: {"target_name": "workflows", "position": "start"}
 -- THIS WILL BE REPLACED
 -- facture_json: {"target_name": "workflows", "position": "end"}
@@ -24,7 +22,6 @@ insert into users (
   first_name,
   last_name
 )
-values
 -- facture_json: {"target_name": "users", "position": "start"}
 -- THIS WILL BE REPLACED
 -- facture_json: {"target_name": "users", "position": "end"}

--- a/tests/examples/json_output/expected_output.json
+++ b/tests/examples/json_output/expected_output.json
@@ -15,7 +15,7 @@
                 "generated": {
                     "id": 23000010000
                 },
-                "output_sql": "-- facture_group_prod1\n(\n  23000010000,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod1\n  23000010000,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -42,7 +42,7 @@
                 "generated": {
                     "id": 21000010000
                 },
-                "output_sql": "-- facture_group_prod1\n(\n  21000010000,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod1\n  21000010000,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -69,7 +69,7 @@
                 "generated": {
                     "id": 21000010001
                 },
-                "output_sql": "-- facture_group_prod1\n(\n  21000010001,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod1\n  21000010001,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -98,7 +98,7 @@
                 "generated": {
                     "id": 22000010000
                 },
-                "output_sql": "-- facture_group_prod1\n(\n  22000010000,           -- id\n  21000010000,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod1\n  22000010000,           -- id\n  21000010000,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -133,7 +133,7 @@
                 "generated": {
                     "id": 22000010001
                 },
-                "output_sql": "-- facture_group_prod1\n(\n  22000010001,           -- id\n  21000010001,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod1\n  22000010001,           -- id\n  21000010001,           -- product_id\n  23000010000,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -170,7 +170,7 @@
                 "generated": {
                     "id": 23000001001
                 },
-                "output_sql": "-- facture_group_prod2\n(\n  23000001001,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod2\n  23000001001,           -- id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -197,7 +197,7 @@
                 "generated": {
                     "id": 21000001002
                 },
-                "output_sql": "-- facture_group_prod2\n(\n  21000001002,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod2\n  21000001002,           -- id\n  '0000001234',          -- classified_code\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},
@@ -226,7 +226,7 @@
                 "generated": {
                     "id": 22000001002
                 },
-                "output_sql": "-- facture_group_prod2\n(\n  22000001002,           -- id\n  21000001002,           -- product_id\n  23000001001,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at\n)",
+                "output_sql": "  -- facture_group_prod2\n  22000001002,           -- id\n  21000001002,           -- product_id\n  23000001001,           -- retailer_id\n  '2018-01-01 00:00:00', -- created_at\n  '2018-01-01 00:00:00'  -- updated_at",
                 "raw": {
                     "attrs": {},
                     "ref_objs": {},

--- a/tests/examples/sql_inject_target/expected_result.sql
+++ b/tests/examples/sql_inject_target/expected_result.sql
@@ -3,25 +3,22 @@ insert into actors (
   first_name,
   last_name
 )
-values
 -- facture_json: {"target_name": "actors", "position": "start"}
-
--- facture_group_shawshank_redemption
-(
+select
+  -- facture_group_shawshank_redemption
   110,       -- id
   $build_id, -- job_run_id
   'Morgan',  -- first_name
   'Freeman'  -- last_name
-),
 
--- facture_group_shawshank_redemption
-(
+union all
+
+select
+  -- facture_group_shawshank_redemption
   111,       -- id
   $build_id, -- job_run_id
   'Tim',     -- first_name
   'Robbins'  -- last_name
-)
-
 -- facture_json: {"target_name": "actors", "position": "end"}
 ;
 
@@ -30,16 +27,14 @@ insert into films (
   name,
   year
 )
-values
 -- facture_json: {"target_name": "films", "position": "start"}
-
--- facture_group_shawshank_redemption
+values
 (
+  -- facture_group_shawshank_redemption
   200,                    -- id
   'Shawshank Redemption', -- name
   '1994'                  -- year
 )
-
 -- facture_json: {"target_name": "films", "position": "end"}
 ;
 
@@ -48,22 +43,20 @@ insert into roles (
   actor_id,
   film_id
 )
-values
 -- facture_json: {"target_name": "roles", "position": "start"}
-
--- facture_group_shawshank_redemption
+values
 (
+  -- facture_group_shawshank_redemption
   1100, -- id
   110,  -- actor_id
   200   -- film_id
 ),
 
--- facture_group_shawshank_redemption
 (
+  -- facture_group_shawshank_redemption
   1101, -- id
   111,  -- actor_id
   200   -- film_id
 )
-
 -- facture_json: {"target_name": "roles", "position": "end"}
 ;

--- a/tests/examples/sql_inject_target/factureconf.py
+++ b/tests/examples/sql_inject_target/factureconf.py
@@ -92,6 +92,7 @@ def conf_targets():
     return [
         {
             'name': 'actors',
+            'format': 'select_unionall',
             'type': 'section_in_file',
             'filename': 'test_output/sql_inject_target/result.sql',
             'section_name': 'actors'

--- a/tests/examples/sql_inject_target/original.sql
+++ b/tests/examples/sql_inject_target/original.sql
@@ -3,7 +3,6 @@ insert into actors (
   first_name,
   last_name
 )
-values
 -- facture_json: {"target_name": "actors", "position": "start"}
 -- THIS WILL BE REPLACED
 -- facture_json: {"target_name": "actors", "position": "end"}
@@ -14,7 +13,6 @@ insert into films (
   name,
   year
 )
-values
 -- facture_json: {"target_name": "films", "position": "start"}
 -- THIS WILL BE REPLACED
 -- facture_json: {"target_name": "films", "position": "end"}
@@ -25,7 +23,6 @@ insert into roles (
   actor_id,
   film_id
 )
-values
 -- facture_json: {"target_name": "roles", "position": "start"}
 -- THIS WILL BE REPLACED
 -- facture_json: {"target_name": "roles", "position": "end"}


### PR DESCRIPTION
First pass. Moves the place where the parenthesis are wrapped to where the SQL is built so we can just use the target conf. Seemed like a better place than the table conf since it's specific to SQL formatting.